### PR TITLE
Property refactoring

### DIFF
--- a/core/BaseView.qml
+++ b/core/BaseView.qml
@@ -146,7 +146,8 @@ BaseLayout {
 			var row = this.model.get(idx)
 			row.index = idx
 			item._local.model = row
-			_globals.core.Object.prototype._update.call(item, '_row')
+			var _row = item._createPropertyStorage('_row')
+			_row.callOnChanged(item, '_row')
 		}
 	}
 
@@ -155,7 +156,8 @@ BaseLayout {
 		var item = this._items[idx]
 		if (item) {
 			item._local.model.index = idx
-			_globals.core.Object.prototype._update.call(item, '_rowIndex')
+			var _rowIndex = item._createPropertyStorage('_rowIndex')
+			_rowIndex.callOnChanged(item, '_rowIndex')
 		}
 	}
 

--- a/core/Object.qml
+++ b/core/Object.qml
@@ -1,9 +1,9 @@
 ///the most basic QML Object, generic event emitter, properties and id links holder
 EventEmitter {
-	///@private
 	constructor: {
 		this.parent = parent
 		this.children = []
+		this.__properties = {}
 
 		this._context = parent? parent._context: null
 		if (row) {
@@ -14,7 +14,7 @@ EventEmitter {
 		this._changedHandlers = {}
 		this._changedConnections = []
 		this._pressedHandlers = {}
-		this._animations = {}
+		this._properties = {}
 		this._updaters = {}
 	}
 
@@ -50,7 +50,7 @@ EventEmitter {
 		this._local = {}
 		this._changedHandlers = {}
 		this._pressedHandlers = {}
-		this._animations = {}
+		this._properties = {}
 		//for(var name in this._updaters) //fixme: it was added once, then removed, is it needed at all? it double-deletes callbacks
 		//	this._replaceUpdater(name)
 		this._updaters = {}
@@ -164,19 +164,28 @@ EventEmitter {
 			handlers.forEach(invoker)
 	}
 
+	///@private creates property storage
+	function _createPropertyStorage(name, value) {
+		var storage = this.__properties[name]
+		if (storage !== undefined)
+			return storage
+
+		return this.__properties[name] = new _globals.core.core.PropertyStorage(value)
+	}
+
+	///mixin api: set default forwarding _target
+	function setPropertyForwardingTarget(name, target) {
+		this._createPropertyStorage(name).forwardTarget = target
+	}
+
 	///@private patch property storage directly without signalling.
 	function _setProperty(name, value) {
-		var animation = this._animations[name]
+		//cancel any running software animations
+		var storage = this._createPropertyStorage(name, value)
+		var animation = storage.animation
 		if (animation !== undefined)
 			animation.disable()
-
-		//cancel any running software animations
-		var storageName = '__property_' + name
-		var storage = this[storageName] || {}
-		delete storage.interpolatedValue
-		storage.value = value
-		this[storageName] = storage
-
+		storage.interpolatedValue = undefined
 		if (animation !== undefined)
 			animation.enable()
 	}
@@ -196,22 +205,12 @@ EventEmitter {
 		if (name === 'contentX' || name === 'contentY')
 			log('WARNING: you\'re trying to animate contentX/contentY property, this will always use animation frames, ignoring CSS transitions, please use content.x/content.y instead')
 
-		var component = this
-		animation._target = component
+		animation._target = this
 		animation._property = name
-		context.scheduleAction(function() {
-			component._animations[name] = animation
-			if (backend.setAnimation(component, name, animation))
-				animation._native = true
-		}, 1)
-	}
-
-	///@private gets animation on given property
-	function getAnimation (name, animation) {
-		if (!this._context._completed)
-			return null
-		var a = this._animations[name]
-		return (a !== undefined && a.enabled() && !a._native)? a:  null;
+		var storage = this._createPropertyStorage(name)
+		storage.animation = animation
+		if (backend.setAnimation(this, name, animation))
+			animation._native = true
 	}
 
 	///@private called to test if the component can have focus, generic object cannot be focused, so return false, override it to implement default focus policy

--- a/core/Object.qml
+++ b/core/Object.qml
@@ -164,12 +164,7 @@ EventEmitter {
 			handlers.forEach(invoker)
 	}
 
-	///mixin api: sets default property forwarding target
-	function setPropertyForwardingTarget(name, target) {
-		this['__forward_' + name] = target
-	}
-
-	///@private patch property storage directly without signalling. You normally don't need it
+	///@private patch property storage directly without signalling. 
 	function _setProperty(name, value) {
 		var animation = this._animations[name]
 		if (animation !== undefined)

--- a/core/Object.qml
+++ b/core/Object.qml
@@ -164,7 +164,7 @@ EventEmitter {
 			handlers.forEach(invoker)
 	}
 
-	///@private patch property storage directly without signalling. 
+	///@private patch property storage directly without signalling.
 	function _setProperty(name, value) {
 		var animation = this._animations[name]
 		if (animation !== undefined)

--- a/core/Transform.qml
+++ b/core/Transform.qml
@@ -16,23 +16,20 @@ Object {
 	///@private
 	constructor: { this._transforms = {} }
 
-	///@private
-	function _update(name, value) {
-		switch(name) {
-			case 'perspective':	this._transforms['perspective'] = value + 'px'; break;
-			case 'translateX':	this._transforms['translateX'] = value + 'px'; break;
-			case 'translateY':	this._transforms['translateY'] = value + 'px'; break;
-			case 'translateZ':	this._transforms['translateZ'] = value + 'px'; break;
-			case 'rotateX':	this._transforms['rotateX'] = value + 'deg'; break
-			case 'rotateY':	this._transforms['rotateY'] = value + 'deg'; break
-			case 'rotateZ':	this._transforms['rotateZ'] = value + 'deg'; break
-			case 'rotate':	this._transforms['rotate'] = value + 'deg'; break
-			case 'scaleX':	this._transforms['scaleX'] = value; break
-			case 'scaleY':	this._transforms['scaleY'] = value; break
-			case 'skewX':	this._transforms['skewX'] = value + 'deg'; break
-			case 'skewY':	this._transforms['skewY'] = value + 'deg'; break
-		}
+	onPerspectiveChanged:	{ this._transforms['perspective'] = value + 'px'; this._updateTransform() }
+	onTranslateXChanged:	{ this._transforms['translateX'] = value + 'px'; this._updateTransform() }
+	onTranslateYChanged:	{ this._transforms['translateY'] = value + 'px'; this._updateTransform() }
+	onTranslateZChanged:	{ this._transforms['translateZ'] = value + 'px'; this._updateTransform() }
+	onRotateXChanged:		{ this._transforms['rotateX'] = value + 'deg'; this._updateTransform() }
+	onRotateYChanged:		{ this._transforms['rotateY'] = value + 'deg'; this._updateTransform() }
+	onRotateZChanged:		{ this._transforms['rotateZ'] = value + 'deg'; this._updateTransform() }
+	onRotateChanged:		{ this._transforms['rotate'] = value + 'deg'; this._updateTransform() }
+	onScaleXChanged:		{ this._transforms['scaleX'] = value; this._updateTransform() }
+	onScaleYChanged:		{ this._transforms['scaleY'] = value; this._updateTransform() }
+	onSkewXChanged:			{ this._transforms['skewX'] = value + 'deg'; this._updateTransform() }
+	onSkewYChanged:			{ this._transforms['skewY'] = value + 'deg'; this._updateTransform() }
 
+	function _updateTransform() {
 		var str = ""
 		for (var i in this._transforms) {
 			str += i

--- a/core/Transform.qml
+++ b/core/Transform.qml
@@ -36,6 +36,5 @@ Object {
 			str += "(" + this._transforms[i] + ") "
 		}
 		this.parent.style('transform', str)
-		_globals.core.Object.prototype._update.apply(this, arguments)
 	}
 }

--- a/core/core.js
+++ b/core/core.js
@@ -210,7 +210,7 @@ exports.addLazyProperty = function(proto, name, creator) {
 
 		set: function(newValue) {
 			var storage = get(this)
-			if (storage.forwardSet(this, newValue, storage.value))
+			if (storage.forwardSet(this, newValue, defaultValue))
 				return
 
 			throw new Error('could not set lazy property ' + name + ' in ' + proto.componentName)
@@ -235,12 +235,12 @@ PropertyStoragePrototype.getAnimation = function(name, animation) {
 	return a
 }
 
-PropertyStoragePrototype.forwardSet = function(object, newValue) {
+PropertyStoragePrototype.forwardSet = function(object, newValue, defaultValue) {
 	var forwardTarget = this.forwardTarget
 	if (forwardTarget === undefined)
 		return false
 
-	var oldValue = this.value
+	var oldValue = this.getCurrentValue(defaultValue)
 	if (oldValue !== null && (oldValue instanceof Object)) {
 		//forward property update for mixins
 		var forwardedOldValue = oldValue[forwardTarget]
@@ -273,7 +273,7 @@ PropertyStoragePrototype.set = function(object, name, newValue, defaultValue, ca
 
 	if (oldValue === newValue)
 		return
-	if (this.forwardSet(object, newValue, oldValue))
+	if (this.forwardSet(object, newValue, defaultValue))
 		return
 	this.value = newValue
 	if (callUpdate)

--- a/core/core.js
+++ b/core/core.js
@@ -239,6 +239,32 @@ PropertyStoragePrototype.getAnimation = function(name, animation) {
 	return a
 }
 
+PropertyStoragePrototype.removeUpdater = function() {
+	var updater = this.updater
+	if (updater === undefined)
+		return
+
+	var callback = updater[0]
+	updater[1].forEach(function(data) {
+		var object = data[0]
+		var name = data[1]
+		object.removeOnChanged(name, callback)
+	})
+	this.updater = undefined
+}
+
+PropertyStoragePrototype.replaceUpdater = function(object, updater) {
+	this.removeUpdater()
+	this.updater = updater
+	var callback = updater[0]
+	updater[1].forEach(function(data) {
+		var object = data[0]
+		var name = data[1]
+		object.connectOnChanged(object, name, callback)
+	})
+	callback()
+}
+
 PropertyStoragePrototype.forwardSet = function(object, newValue, defaultValue) {
 	var forwardTarget = this.forwardTarget
 	if (forwardTarget === undefined)
@@ -262,6 +288,10 @@ PropertyStoragePrototype.forwardSet = function(object, newValue, defaultValue) {
 		})
 		return false
 	}
+}
+
+PropertyStoragePrototype.discard = function() {
+
 }
 
 PropertyStoragePrototype.getSimpleValue = function(defaultValue) {

--- a/core/core.js
+++ b/core/core.js
@@ -241,6 +241,8 @@ exports.addProperty = function(proto, type, name, defaultValue) {
 		case 'bool':	convert = function(value) { return value? true: false }; break
 		case 'real':	convert = function(value) { return +value }; animable = true; break
 		case 'string':	convert = function(value) { return String(value) }; break
+
+		case 'Color':	animable = true; //fallthrough
 		default:		convert = function(value) { return value }; break
 	}
 

--- a/core/core.js
+++ b/core/core.js
@@ -253,14 +253,14 @@ PropertyStoragePrototype.removeUpdater = function() {
 	this.updater = undefined
 }
 
-PropertyStoragePrototype.replaceUpdater = function(object, updater) {
+PropertyStoragePrototype.replaceUpdater = function(parent, updater) {
 	this.removeUpdater()
 	this.updater = updater
 	var callback = updater[0]
 	updater[1].forEach(function(data) {
 		var object = data[0]
 		var name = data[1]
-		object.connectOnChanged(object, name, callback)
+		parent.connectOnChanged(object, name, callback)
 	})
 	callback()
 }


### PR DESCRIPTION
removed object-centric property handler, used simplified code for non-animable get/set, put everything into PropertyStorage, instead of multiple dict-by-name inside qml.Object