### PR TITLE
Fix 9bd111203fc718d72b175643c372bc7c77185745 to make output the same as before

### DIFF
--- a/build
+++ b/build
@@ -118,11 +118,11 @@ block_re = re.compile(r'{%.*?%}', re.MULTILINE | re.IGNORECASE)
 def process_template_simple(destination, source, context):
 	_head, name = path.split(source)
 	destination = path.join(destination, name)
-	with open(destination, 'wb') as fd, open(source) as fs:
+	with open(destination, 'w') as fd, open(source) as fs:
 		data = fs.read()
 		data = var_re.sub(lambda x: context.get(x.group(1), ''), data)
 		data = block_re.sub('', data)
-		fd.write(data.encode('utf-8'))
+		fd.write(data)
 
 def process_template_jinja2(destination, source, context):
 	from jinja2 import Environment, FileSystemLoader, BaseLoader, TemplateNotFound

--- a/compiler/doc/json.py
+++ b/compiler/doc/json.py
@@ -65,7 +65,7 @@ class Component(object):
 				docText = (docLines[-1] if descriptionAtLastLine else docLines[0]).strip(' *').lstrip()
 				r.append('\t\t\t"%s": { "text": "%s", %s"internal": %s }%s' %(value.name[0], docText, argText, internal, localComma))
 			else:
-				itemName = value.name if isinstance(value.name, basestring) else value.name[0]
+				itemName = value.name if isinstance(value.name, (str, basestring)) else value.name[0]
 				r.append('\t\t\t"%s": { "text": "%s", "internal": %s }%s' %(itemName, docText, internal, localComma))
 
 		if comma:

--- a/compiler/grammar.py
+++ b/compiler/grammar.py
@@ -310,7 +310,7 @@ def handle_ternary_op(s, l, t):
 def handle_percent_number(s, l, t):
 	value = t[0]
 	strvalue = lang.to_string(value)
-	return ("((%s) / 100 * ${parent.<property-name>})" %strvalue) if strvalue != 100 else "(${parent.<property-name>})"
+	return ("((%s) / 100 * ${parent.<property-name>})" %strvalue) if value != 100 else "(${parent.<property-name>})"
 
 percent_number = number + '%'
 percent_number.setParseAction(handle_percent_number)

--- a/compiler/js/component.py
+++ b/compiler/js/component.py
@@ -565,7 +565,7 @@ class component_generator(object):
 			t = type(value)
 			#print self.name, target, value
 			target_owner, target_lvalue, target_prop = self.get_lvalue(registry, parent, target)
-			if isinstance(value, str):
+			if isinstance(value, (str, basestring)):
 				value = replace_enums(value, self, registry)
 				r.append('//assigning %s to %s' %(target, value))
 				value, deps = parse_deps(parent, value, partial(self.transform_root, registry))

--- a/compiler/lang.py
+++ b/compiler/lang.py
@@ -1,4 +1,6 @@
+from __future__ import unicode_literals
 from builtins import object, str
+from past.builtins import basestring
 
 import re
 
@@ -6,8 +8,10 @@ def value_is_trivial(value):
 	if isinstance(value, bool):
 		return True
 
-	if value is None or not isinstance(value, str):
+	if value is None or not isinstance(value, (str, basestring)):
 		return False
+
+	value = str(value)
 
 	if value[0] == '(' and value[-1] == ')':
 		value = value[1:-1]
@@ -30,7 +34,7 @@ def value_is_trivial(value):
 	return False
 
 def to_string(value):
-	if isinstance(value, str):
+	if isinstance(value, (str, basestring)):
 		return value
 	elif isinstance(value, bool):
 		return 'true' if value else 'false'
@@ -105,7 +109,7 @@ class Assignment(Entity):
 		elif property_name == 'y':
 			property_name = 'height'
 
-		if isinstance(value, str):
+		if isinstance(value, (str, basestring)):
 			self.value = Assignment.re_name.sub(property_name, value)
 		else:
 			self.value = to_string(value)


### PR DESCRIPTION
Note: output for Python 2 and Python 3 differs because of sorting in
dicts, etc., but theoretically should be the same semantically.