### PR TITLE
add failing test for parsing of floats that have no integer before decimal point

### DIFF
--- a/test/qml/float_parse.qml
+++ b/test/qml/float_parse.qml
@@ -1,0 +1,4 @@
+// RUN: %build
+Text {
+    opacity: .8;
+}


### PR DESCRIPTION
I would expect the following to parse correctly (and it did before the recent parser rewrite):

```
// RUN: %build
Text {
    opacity: .8;
}
```

```
-- Testing: 1 tests, 1 workers --
FAIL: Compiler Tests :: qml/float_parse.qml (1 of 1)
******************** TEST 'Compiler Tests :: qml/float_parse.qml' FAILED ********************
Script:
--
: 'RUN: at line 1';   : rm -f /local2/b/indigo-gui/third/qmlcore/test/../test/.cache/test.float_parse && rm -rf build.float_parse.qml && cd /local2/b/indigo-gui/third/qmlcore/test/../test && /local2/b/indigo-gui/third/qmlcore/test/../bu\
ild -v --build-dir=build.float_parse.qml --cache-dir=/local2/b/indigo-gui/third/qmlcore/test/../test/.cache --inline-manifest='{"sources":"qml","apps":["float_parse"],"package":"test"}'
--
Exit Code: 1

Command Output (stderr):
--
building float_parse for web...
running using 1 jobs
including platform initialisation file at /local2/b/indigo-gui/third/qmlcore/test/../platform/html5/.core.js
including platform initialisation file at /local2/b/indigo-gui/third/qmlcore/test/../platform/video.html5/.core.js
including platform initialisation file at /local2/b/indigo-gui/third/qmlcore/test/../platform/web/.core.js
including js file... /local2/b/indigo-gui/third/qmlcore/test/../core/transform.js
including js file... /local2/b/indigo-gui/third/qmlcore/test/../core/core.js
including js file... /local2/b/indigo-gui/third/qmlcore/test/../core/model.js
including js file... /local2/b/indigo-gui/third/qmlcore/test/../core/gradient.js
including js file... /local2/b/indigo-gui/third/qmlcore/test/../platform/html5/cache.js
including js file... /local2/b/indigo-gui/third/qmlcore/test/../platform/html5/html.js
including js file... /local2/b/indigo-gui/third/qmlcore/test/../platform/html5/localstorage.js
including js file... /local2/b/indigo-gui/third/qmlcore/test/../platform/html5/location.js
including js file... /local2/b/indigo-gui/third/qmlcore/test/../platform/video.html5/backend.js
including js file... /local2/b/indigo-gui/third/qmlcore/test/../platform/web/device.js
parsing qml/float_parse.qml ... test.float_parse
qml/float_parse.qml: error: at line 3:16:
    opacity: .8;
               ^-- Unexpected token in infix expression: '.'
error: at line 3:16:
    opacity: .8;
               ^-- Unexpected token in infix expression: '.'
Traceback (most recent call last):
  File "/local2/b/indigo-gui/third/qmlcore/compiler/__init__.py", line 52, in read
    with open(cached_path, 'rb') as f:
FileNotFoundError: [Errno 2] No such file or directory: '/local2/b/indigo-gui/third/qmlcore/test/../test/.cache/test.float_parse'


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/local2/b/indigo-gui/third/qmlcore/test/../build", line 467, in <module>
    build(root, platform, apps, app, manifest)
  File "/local2/b/indigo-gui/third/qmlcore/test/../build", line 348, in build
    compile_qml(target, root, project_dirs, manifest, app, **kw)
  File "/local2/b/indigo-gui/third/qmlcore/compiler/__init__.py", line 319, in compile_qml
    c.generate()
  File "/local2/b/indigo-gui/third/qmlcore/compiler/__init__.py", line 207, in generate
    self.process_files(None, generator)
  File "/local2/b/indigo-gui/third/qmlcore/compiler/__init__.py", line 164, in process_files
    promise = self.process_file(pool, generator, package, dirpath, filename)
  File "/local2/b/indigo-gui/third/qmlcore/compiler/__init__.py", line 96, in process_file
    tree, data = parse_qml_file(self.cache, com, path)
  File "/local2/b/indigo-gui/third/qmlcore/compiler/__init__.py", line 77, in parse_qml_file
    return cache.read(com, path)
  File "/local2/b/indigo-gui/third/qmlcore/compiler/__init__.py", line 61, in read
    tree = compiler.grammar2.parse(data)
  File "/local2/b/indigo-gui/third/qmlcore/compiler/grammar2.py", line 741, in parse
    return parser.parse()
  File "/local2/b/indigo-gui/third/qmlcore/compiler/grammar2.py", line 730, in parse
    r = [self.__read_comp()]
  File "/local2/b/indigo-gui/third/qmlcore/compiler/grammar2.py", line 723, in __read_comp
    children.append(self.__read_scope_decl())
  File "/local2/b/indigo-gui/third/qmlcore/compiler/grammar2.py", line 715, in __read_scope_decl
    return self.__read_rules_with_id(identifiers)
  File "/local2/b/indigo-gui/third/qmlcore/compiler/grammar2.py", line 603, in __read_rules_with_id
    value = self.__read_expression()
  File "/local2/b/indigo-gui/third/qmlcore/compiler/grammar2.py", line 535, in __read_expression
    value = infix_parser.parse(self)
  File "/local2/b/indigo-gui/third/qmlcore/compiler/grammar2.py", line 205, in parse
    return self.expression(state)
  File "/local2/b/indigo-gui/third/qmlcore/compiler/grammar2.py", line 193, in expression
    left = t.nud(state)
  File "/local2/b/indigo-gui/third/qmlcore/compiler/grammar2.py", line 231, in nud
    state.parser.error("Unexpected token in infix expression: '%s'" %self.term)
  File "/local2/b/indigo-gui/third/qmlcore/compiler/grammar2.py", line 453, in error
    raise Exception("at line %d:%d:\n%s\n%s" %(lineno, col, self.current_line, pointer))
Exception: at line 3:16:
    opacity: .8;
               ^-- Unexpected token in infix expression: '.'

--
```