### PR TITLE
add failing test for parse failure when property type name includes underscore

### DIFF
--- a/test/qml/underscore_in_property_type.qml
+++ b/test/qml/underscore_in_property_type.qml
@@ -1,0 +1,4 @@
+// RUN: %build
+Text {
+    property my_special_type__ value;
+}


### PR DESCRIPTION
I would expect the following to parse correctly (and I believe it did before the recent parser rewrite). my_special_type__ is any arbitrary js type defined elsewhere (not by qml).

```
// RUN: %build
Text {
    property my_special_type__ value;
}
```

```
-- Testing: 1 tests, 1 workers --
FAIL: Compiler Tests :: qml/underscore_in_property_type.qml (1 of 1)
******************** TEST 'Compiler Tests :: qml/underscore_in_property_type.qml' FAILED ********************
Script:
--
: 'RUN: at line 1';   : rm -f /local2/b/indigo-gui/third/qmlcore/test/../test/.cache/test.underscore_in_property_type && rm -rf build.underscore_in_property_type.qml && cd /local2/b/indigo-gui/third/qmlcore/test/../test && /local2/b/ind\
igo-gui/third/qmlcore/test/../build -v --build-dir=build.underscore_in_property_type.qml --cache-dir=/local2/b/indigo-gui/third/qmlcore/test/../test/.cache --inline-manifest='{"sources":"qml","apps":["underscore_in_property_type"],"pack\
age":"test"}'
--
Exit Code: 1

Command Output (stderr):
--
building underscore_in_property_type for web...
running using 1 jobs
including platform initialisation file at /local2/b/indigo-gui/third/qmlcore/test/../platform/html5/.core.js
including platform initialisation file at /local2/b/indigo-gui/third/qmlcore/test/../platform/video.html5/.core.js
including platform initialisation file at /local2/b/indigo-gui/third/qmlcore/test/../platform/web/.core.js
including js file... /local2/b/indigo-gui/third/qmlcore/test/../core/transform.js
including js file... /local2/b/indigo-gui/third/qmlcore/test/../core/core.js
including js file... /local2/b/indigo-gui/third/qmlcore/test/../core/model.js
including js file... /local2/b/indigo-gui/third/qmlcore/test/../core/gradient.js
including js file... /local2/b/indigo-gui/third/qmlcore/test/../platform/html5/cache.js
including js file... /local2/b/indigo-gui/third/qmlcore/test/../platform/html5/html.js
including js file... /local2/b/indigo-gui/third/qmlcore/test/../platform/html5/localstorage.js
including js file... /local2/b/indigo-gui/third/qmlcore/test/../platform/html5/location.js
including js file... /local2/b/indigo-gui/third/qmlcore/test/../platform/video.html5/backend.js
including js file... /local2/b/indigo-gui/third/qmlcore/test/../platform/web/device.js
parsing qml/underscore_in_property_type.qml ... test.underscore_in_property_type
qml/underscore_in_property_type.qml: error: at line 3:32:
    property my_special_type__ value;
                               ^-- Expected ; at the end of the statement
error: at line 3:32:
    property my_special_type__ value;
                               ^-- Expected ; at the end of the statement
Traceback (most recent call last):
  File "/local2/b/indigo-gui/third/qmlcore/compiler/__init__.py", line 52, in read
    with open(cached_path, 'rb') as f:
FileNotFoundError: [Errno 2] No such file or directory: '/local2/b/indigo-gui/third/qmlcore/test/../test/.cache/test.underscore_in_property_type'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/local2/b/indigo-gui/third/qmlcore/test/../build", line 467, in <module>
    build(root, platform, apps, app, manifest)
  File "/local2/b/indigo-gui/third/qmlcore/test/../build", line 348, in build
    compile_qml(target, root, project_dirs, manifest, app, **kw)
  File "/local2/b/indigo-gui/third/qmlcore/compiler/__init__.py", line 319, in compile_qml
    c.generate()
  File "/local2/b/indigo-gui/third/qmlcore/compiler/__init__.py", line 207, in generate
    self.process_files(None, generator)
  File "/local2/b/indigo-gui/third/qmlcore/compiler/__init__.py", line 164, in process_files
    promise = self.process_file(pool, generator, package, dirpath, filename)
  File "/local2/b/indigo-gui/third/qmlcore/compiler/__init__.py", line 96, in process_file
    tree, data = parse_qml_file(self.cache, com, path)
  File "/local2/b/indigo-gui/third/qmlcore/compiler/__init__.py", line 77, in parse_qml_file
    return cache.read(com, path)
  File "/local2/b/indigo-gui/third/qmlcore/compiler/__init__.py", line 61, in read
    tree = compiler.grammar2.parse(data)
  File "/local2/b/indigo-gui/third/qmlcore/compiler/grammar2.py", line 741, in parse
    return parser.parse()
  File "/local2/b/indigo-gui/third/qmlcore/compiler/grammar2.py", line 730, in parse
    r = [self.__read_comp()]
  File "/local2/b/indigo-gui/third/qmlcore/compiler/grammar2.py", line 723, in __read_comp
    children.append(self.__read_scope_decl())
  File "/local2/b/indigo-gui/third/qmlcore/compiler/grammar2.py", line 689, in __read_scope_decl
    return self.__read_property()
  File "/local2/b/indigo-gui/third/qmlcore/compiler/grammar2.py", line 577, in __read_property
    self.__read_statement_end()
  File "/local2/b/indigo-gui/third/qmlcore/compiler/grammar2.py", line 494, in __read_statement_end
    self.read(';', "Expected ; at the end of the statement")
  File "/local2/b/indigo-gui/third/qmlcore/compiler/grammar2.py", line 490, in read
    self.error(error)
  File "/local2/b/indigo-gui/third/qmlcore/compiler/grammar2.py", line 453, in error
    raise Exception("at line %d:%d:\n%s\n%s" %(lineno, col, self.current_line, pointer))
Exception: at line 3:32:
    property my_special_type__ value;
                               ^-- Expected ; at the end of the statement

--
```