### PR TITLE
fix: correct occured to occurred typo in property comment

### DIFF
--- a/core/Request.qml
+++ b/core/Request.qml
@@ -1,6 +1,6 @@
 ///object for handling XML/HTTP requests
 Object {
-	property bool loading: false;	///< loading flag, is true when request was send and false when answer was recieved or error occured
+	property bool loading: false;	///< loading flag, is true when request was send and false when answer was recieved or error occurred
 
 	/**@param request:Object request object
 	send request using 'XMLHttpRequest' object*/


### PR DESCRIPTION
Fixes 'occured' → 'occurred' typo in a QML property comment in core/Request.qml.

Surgical fix, 1 file, 1 line. GH007 compliant.